### PR TITLE
allow custom wsgi location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'berkshelf'
 # end
 
 gem 'test-kitchen'
+gem 'kitchen-openstack'
 gem 'kitchen-vagrant'
 gem 'rubocop'
 gem 'foodcritic'

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Option                  | Type      | Description                               
 `:django_collectstatic` | Boolean   | Whether or not to run django collectstatic    | `false`
 `:interpreter`          | String    | Python command (python, python3, etc)         | `python`
 `:gunicorn_port`        | Int/Nil   | Port to run gunicorn on                       | `nil`
+`:wsgi_module`          | String/Nil| wsgi module and variable for gunicorn to use  | `nil` with a [calculated default](#notes).
 
 For more information on some of these resources (and the sane defaults
 python-webapp sets in case of certain values being) see the [Notes
@@ -48,7 +49,7 @@ section](#notes) below.
 ### Example
 
 **SETUP:** Before you can use the python-webapp cookbook add the following
-informtion to the corresponding files:
+information to the corresponding files:
 
 * Add `depends 'python-webapp'` to your metadata.rb.
 * Add `cookbook 'python-webapp', git:
@@ -103,6 +104,7 @@ More examples of the python-webapp's usage can be found in this
 * `config_destination` is calculated to be `${ path }/settings.py`
 * `requirements_file` is calculated to be `setup.py`
 * `config_template` is calculated to be `settings.py.erb`
+* `wsgi_module` is calculated to be `# {project_name }.wsgi:application`
 
 **Python Versions:** If you are using a version of python in `interpreter` that
 does not come by default on your system you have to install this seperately;

--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ More examples of the python-webapp's usage can be found in this
 ### Notes
 
 **Sane Defaults:**
-* `path` is calculated as `/opt/${ project_name }`
-* `virtualenv_path` is calculated to be `/opt/${ project_name }/venv`
-* `config_destination` is calculated to be `${ path }/settings.py`
+* `path` is calculated as `/opt/#{ project_name }`
+* `virtualenv_path` is calculated to be `/opt/#{ project_name }/venv`
+* `config_destination` is calculated to be `#{ path }/settings.py`
 * `requirements_file` is calculated to be `setup.py`
 * `config_template` is calculated to be `settings.py.erb`
-* `wsgi_module` is calculated to be `${project_name }.wsgi:application`
+* `wsgi_module` is calculated to be `#{project_name }.wsgi:application`
 
 **Python Versions:** If you are using a version of python in `interpreter` that
 does not come by default on your system you have to install this seperately;

--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ More examples of the python-webapp's usage can be found in this
 ### Notes
 
 **Sane Defaults:**
-* `path` is calculated as `/opt/#{ project_name }`
-* `virtualenv_path` is calculated to be `/opt/#{ project_name }/venv`
+* `path` is calculated as `/opt/${ project_name }`
+* `virtualenv_path` is calculated to be `/opt/${ project_name }/venv`
 * `config_destination` is calculated to be `${ path }/settings.py`
 * `requirements_file` is calculated to be `setup.py`
 * `config_template` is calculated to be `settings.py.erb`
-* `wsgi_module` is calculated to be `# {project_name }.wsgi:application`
+* `wsgi_module` is calculated to be `${project_name }.wsgi:application`
 
 **Python Versions:** If you are using a version of python in `interpreter` that
 does not come by default on your system you have to install this seperately;

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -154,11 +154,8 @@ action :install do
       listen "0.0.0.0:#{new_resource.gunicorn_port}"
     end
 
-    if new_resource.wsgi_module.nil?
-      wsgi_module = "#{new_resource.name}.wsgi:application"
-    else
-      wsgi_module = new_resource.wsgi_module
-    end
+    wsgi_module = new_resource.wsgi_module ||
+                  "#{new_resource.name}.wsgi:application"
 
     supervisor_service new_resource.name do
       command "#{virtualenv_path}/bin/gunicorn " \

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -110,7 +110,7 @@ action :install do
       user new_resource.owner
       cwd "#{path}/source"
       code <<-EOH
-        #{virtualenv_path}/bin/python setup.py install
+        #{virtualenv_path}/bin/python setup.py install # ~FC002
       EOH
     end
 
@@ -127,7 +127,7 @@ action :install do
     user new_resource.owner
     cwd "#{path}/source"
     code <<-EOH
-      #{virtualenv_path}/bin/python manage.py migrate --noinput
+      #{virtualenv_path}/bin/python manage.py migrate --noinput # ~FC002
     EOH
     only_if { new_resource.django_migrate }
   end
@@ -138,7 +138,7 @@ action :install do
     user new_resource.owner
     cwd "#{path}/source"
     code <<-EOH
-      #{virtualenv_path}/bin/python manage.py collectstatic --noinput
+      #{virtualenv_path}/bin/python manage.py collectstatic --noinput # ~FC002
     EOH
     only_if { new_resource.django_collectstatic }
   end
@@ -154,9 +154,15 @@ action :install do
       listen "0.0.0.0:#{new_resource.gunicorn_port}"
     end
 
+    if new_resource.wsgi_module.nil?
+      wsgi_module = "#{new_resource.name}.wsgi:application"
+    else
+      wsgi_module = new_resource.wsgi_module
+    end
+
     supervisor_service new_resource.name do
       command "#{virtualenv_path}/bin/gunicorn " \
-        "#{new_resource.name}.wsgi:application -c #{path}/gunicorn_config.py"
+        "#{wsgi_module} -c #{path}/gunicorn_config.py"
       autorestart true
       directory "#{path}/source"
     end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -43,6 +43,10 @@ attribute :config_template, 'kind_of' => [String, NilClass],
 attribute :config_destination, 'kind_of' => [String, NilClass], :default => nil
 attribute :config_vars, 'kind_of' => Hash
 
+# Port gunicorn will run on. If not nil, supervisor and gunicorn are installed
+attribute :gunicorn_port, 'kind_of' => [Integer, NilClass], :default => nil
+attribute :wsgi_module, 'kind_of' => [String, NilClass], :default => nil
+
 # If this is set, install that requirements file. If it is not, install a
 # setup.py. If the setup.py does not exist, fail.
 attribute :requirements_file, 'kind_of' => [String, NilClass], :default => nil
@@ -55,5 +59,3 @@ attribute :django_collectstatic, 'kind_of' => [TrueClass, FalseClass],
                                  :default => false
 
 attribute :interpreter, 'kind_of' => String, :default => 'python'
-
-attribute :gunicorn_port, 'kind_of' => [Integer, NilClass], :default => nil

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -143,3 +143,20 @@ describe 'python-webapp-test::tutorial_c' do
     expect(chef_run).not_to include_recipe('supervisor')
   end
 end
+
+describe 'python-webapp-test::tutorial_d' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      step_into: ['python_webapp']).converge(described_recipe)
+  end
+
+  it 'installs and sets up supervisor for Tutorial D' do
+    expect(chef_run)
+      .to enable_supervisor_service('tutorial_d').with(
+        command: '/opt/tutorial_d/venv/bin/gunicorn' \
+          ' tutorial_d.wsgi:application' \
+          ' -c /opt/tutorial_d/gunicorn_config.py',
+        autorestart: true,
+        directory: '/opt/tutorial_d/source')
+  end
+end

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -86,7 +86,7 @@ describe 'python-webapp-test::default' do
     expect(chef_run)
       .to enable_supervisor_service('tutorial_a').with(
         command: '/opt/tutorial_a/venv/bin/gunicorn' \
-          ' tutorial_a.wsgi:application' \
+          ' wsgi:app' \
           ' -c /opt/tutorial_a/gunicorn_config.py',
         autorestart: true,
         directory: '/opt/tutorial_a/source')

--- a/test/cookbooks/python-webapp-test/recipes/default.rb
+++ b/test/cookbooks/python-webapp-test/recipes/default.rb
@@ -47,6 +47,7 @@ python_webapp 'tutorial_a' do
   django_collectstatic true
   interpreter 'python2.7'
   revision 'cookbook_test'
+  wsgi_module 'wsgi:app'
 
   gunicorn_port 8888
 end

--- a/test/cookbooks/python-webapp-test/recipes/tutorial_d.rb
+++ b/test/cookbooks/python-webapp-test/recipes/tutorial_d.rb
@@ -1,0 +1,39 @@
+#
+# Cookbook Name:: python-webapp-test
+# Recipe:: tutorial_d
+#
+# Copyright 2015, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'yum-ius'
+include_recipe 'yum-epel'
+
+%w(gcc python27 python27-devel python27-pip).each do |pkg|
+  package pkg
+end
+
+python_webapp 'tutorial_d' do
+  path nil
+  requirements_file 'special_requirements.txt'
+
+  django_migrate false
+  django_collectstatic false
+
+  repository 'https://github.com/osuosl/python-test-apps.git'
+  gunicorn_port 8888
+
+  config_template nil
+  revision 'cookbook_test'
+end


### PR DESCRIPTION
This means that non-Django apps that don't have all of their stuff hidden away don't need to make a `${project_name}/wsgi.py` file, and can instead stick it where ever is convenient for them.

My main problem that I see with this code is that I'm not testing the default anywhere. Would having a new unit test for the default, without integration testing it, be alright? 

@jordane @ramereth @Kennric 
